### PR TITLE
feat(version): use build.hasVersion to enforce minimum version of graphile-build-pg

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "homepage": "https://github.com/graphile/postgis#readme",
   "peerDependencies": {
-    "graphile-build": "^4.3.0",
-    "graphile-build-pg": "^4.3.0",
+    "graphile-build": "^4.4.0",
+    "graphile-build-pg": "^4.4.0",
     "graphql": ">=0.6 <15",
     "pg-sql2": ">=2.2.1 <5"
   },

--- a/src/PostgisVersionPlugin.ts
+++ b/src/PostgisVersionPlugin.ts
@@ -1,0 +1,33 @@
+import { Plugin } from "graphile-build";
+
+const plugin: Plugin = builder => {
+  builder.hook("build", build => {
+    const pkg = require("./../package.json");
+
+    // Check dependencies
+    if (!build.versions) {
+      throw new Error(
+        `Plugin ${pkg.name}@${pkg.version} requires graphile-build@^4.1.0 in order to check dependencies (current version: ${build.graphileBuildVersion})`
+      );
+    }
+    const depends = (name: string, range: string) => {
+      if (!build.hasVersion(name, range)) {
+        throw new Error(
+          `Plugin ${pkg.name}@${pkg.version} requires ${name}@${range} (${
+            build.versions[name]
+              ? `current version: ${build.versions[name]}`
+              : "not found"
+          })`
+        );
+      }
+    };
+    depends("graphile-build-pg", "^4.4.0");
+
+    // Register this plugin
+    build.versions = build.extend(build.versions, { [pkg.name]: pkg.version });
+
+    return build;
+  });
+};
+
+export default plugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Plugin } from "graphile-build";
+import PostgisVersionPlugin from "./PostgisVersionPlugin";
 import PostgisInflectionPlugin from "./PostgisInflectionPlugin";
 import PostgisExtensionDetectionPlugin from "./PostgisExtensionDetectionPlugin";
 import PostgisRegisterTypesPlugin from "./PostgisRegisterTypesPlugin";
@@ -11,6 +12,7 @@ import Postgis_MultiLineString_LineStringsPlugin from "./Postgis_MultiLineString
 import Postgis_MultiPolygon_PolygonsPlugin from "./Postgis_MultiPolygon_PolygonsPlugin";
 
 const PostgisPlugin: Plugin = async (builder, options) => {
+  await PostgisVersionPlugin(builder, options);
   await PostgisInflectionPlugin(builder, options);
   await PostgisExtensionDetectionPlugin(builder, options);
   await PostgisRegisterTypesPlugin(builder, options);


### PR DESCRIPTION
This implements what I suggested here: https://github.com/graphile/postgis/pull/25#issuecomment-524391017

When I ran the test suite locally, the build failed on anything less than 4.4.0-beta.7, so I set the minimum version to 4.4.0.

@benjie You were right about TypeScript complaining after removing those peerDeps, so I left them in place.